### PR TITLE
rating initialization contemplate the zero value

### DIFF
--- a/src/components/ionic3-star-rating-component.ts
+++ b/src/components/ionic3-star-rating-component.ts
@@ -33,7 +33,7 @@ const CSS_STYLE = `
 export class StarRating implements ControlValueAccessor, OnInit{
 
   ngOnInit(): void {
-    this.rating = this.rating || 3; //default after input`s initialization
+    this.rating = Number(this.rating) || 3; //default after input`s initialization
   }
 
   public readonly eventInfo = (()=>{


### PR DESCRIPTION
In the `ngOnInit` method of the `StarRating` component I used the `Number` constructor to avoid the component initializate to 3 stars when the user passed 0 as initial value